### PR TITLE
Add support for custom logging configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package makes it possible to add Datadog spans to your code and connect log
 
 ```Go
 import(
-    github.com/YourSurpriseCom/go-datadog-apm/apm
+    github.com/YourSurpriseCom/go-datadog-apm
 )
 
 apm := apm.NewApm()
@@ -38,6 +38,23 @@ The log level can be configure by setting the environment variable `LOG_LEVEL` w
 * `fatal`
 
 When not set, it will fall back to the value `info`
+
+Other custom logging options can be set by passing zap configurations to the logger constructor, and passing the custom logger to the apm constructor, like so:
+```Go
+import(
+    github.com/YourSurpriseCom/go-datadog-apm/apm
+    github.com/YourSurpriseCom/go-datadog-apm/logger
+)
+
+var myZapConfig *zap.Config // initialized elsewhere
+
+logger := logger.NewLogger(
+    WithConfig(myZapConfig)
+)
+return apm.NewApm(
+    WithLogger(&logger)
+)
+```
 
 ## Serverless Config
 To use the Serverless Datadog agent, build the application based on the following `Dockerfile`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package makes it possible to add Datadog spans to your code and connect log
 
 ```Go
 import(
-    github.com/YourSurpriseCom/go-datadog-apm
+    github.com/YourSurpriseCom/go-datadog-apm/apm
 )
 
 apm := apm.NewApm()

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -21,9 +21,9 @@ type Apm struct {
 
 type ApmOption func(*Apm)
 
-func WithLogger(logger *logger.Logger) ApmOption {
+func WithLogger(logger logger.Logger) ApmOption {
 	return func(apm *Apm) {
-		apm.Logger = logger
+		apm.Logger = &logger
 	}
 }
 

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -27,6 +27,12 @@ func WithLogger(logger *logger.Logger) ApmOption {
 	}
 }
 
+// NewApm creates a new Apm instance with the provided options.
+// Example:
+//
+//	myLogger := &logger.Logger{}
+//	apm := NewApm(WithLogger(myLogger))
+//	apm.Logger.Info(context.Background(), "Hello, world!")
 func NewApm(options ...ApmOption) Apm {
 	apm := Apm{}
 

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -16,14 +16,30 @@ import (
 )
 
 type Apm struct {
-	Logger logger.Logger
+	Logger *logger.Logger
 }
 
-func NewApm() Apm {
-	logger := logger.NewLogger()
-	return Apm{
-		Logger: logger,
+type ApmOption func(*Apm)
+
+func WithLogger(logger *logger.Logger) ApmOption {
+	return func(apm *Apm) {
+		apm.Logger = logger
 	}
+}
+
+func NewApm(options ...ApmOption) Apm {
+	apm := Apm{}
+
+	for _, option := range options {
+		option(&apm)
+	}
+
+	if apm.Logger == nil {
+		logger := logger.NewLogger()
+		apm.Logger = &logger
+	}
+
+	return apm
 }
 
 func (apm Apm) StartSpanFromContext(ctx context.Context, name string) (ddtrace.Span, context.Context) {

--- a/apm/apm_test.go
+++ b/apm/apm_test.go
@@ -23,11 +23,12 @@ func TestNewApm(t *testing.T) {
 		t.Errorf("Logger type incorrect, expected '%s' got '%s'", reflect.TypeOf(logger.Logger{}), reflect.TypeOf(apm.Logger))
 	}
 
-	myLogger := &logger.Logger{}
+	loggerName := "apm-logger"
+	myLogger := logger.NewLogger(logger.WithName(loggerName))
 	apm = NewApm(WithLogger(myLogger))
 
-	if apm.Logger != myLogger {
-		t.Errorf("Logger instance in apm does not match logger in provided option")
+	if apm.Logger.Name() != "apm-logger" {
+		t.Errorf("Apm logger name incorrect, expected '%s' got '%s'", loggerName, apm.Logger.Name())
 	}
 }
 

--- a/apm/apm_test.go
+++ b/apm/apm_test.go
@@ -19,8 +19,15 @@ import (
 func TestNewApm(t *testing.T) {
 	apm := NewApm()
 
-	if reflect.TypeOf(apm.Logger) != reflect.TypeOf(logger.Logger{}) {
+	if reflect.TypeOf(apm.Logger) != reflect.TypeOf(&logger.Logger{}) {
 		t.Errorf("Logger type incorrect, expected '%s' got '%s'", reflect.TypeOf(logger.Logger{}), reflect.TypeOf(apm.Logger))
+	}
+
+	myLogger := &logger.Logger{}
+	apm = NewApm(WithLogger(myLogger))
+
+	if apm.Logger != myLogger {
+		t.Errorf("Logger instance in apm does not match logger in provided option")
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Logger struct {
-	internalLogger *zap.SugaredLogger
+	internalLoggger *zap.SugaredLogger
 }
 
 type LoggerOption func(*Logger)
@@ -24,10 +24,17 @@ func WithConfig(config zap.Config) LoggerOption {
 			fmt.Println("Error building logger", err.Error())
 			panic(err)
 		}
-		l.internalLogger = zapLogger.Sugar()
+		l.internalLoggger = zapLogger.Sugar()
 	}
 }
 
+// NewLogger creates a new Logger instance with the provided options.
+// Example:
+//
+//	logger := NewLogger(WithConfig(zap.Config{
+//		Level:    zap.NewAtomicLevelAt(zapcore.WarnLevel),
+//		Encoding: "console",
+//	}))
 func NewLogger(options ...LoggerOption) Logger {
 	logger := Logger{}
 
@@ -35,8 +42,8 @@ func NewLogger(options ...LoggerOption) Logger {
 		option(&logger)
 	}
 
-	if logger.internalLogger == nil {
-		logger.internalLogger = defaultLogger()
+	if logger.internalLoggger == nil {
+		logger.internalLoggger = defaultLogger()
 	}
 
 	return logger
@@ -84,27 +91,27 @@ func defaultLogger() *zap.SugaredLogger {
 func (log Logger) Debug(ctx context.Context, template string, args ...interface{}) {
 	span, ok := tracer.SpanFromContext(ctx)
 	if ok {
-		log.internalLogger.Debugw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
+		log.internalLoggger.Debugw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
 	} else {
-		log.internalLogger.Debugf(template, args...)
+		log.internalLoggger.Debugf(template, args...)
 	}
 }
 
 func (log Logger) Info(ctx context.Context, template string, args ...interface{}) {
 	span, ok := tracer.SpanFromContext(ctx)
 	if ok {
-		log.internalLogger.Infow(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
+		log.internalLoggger.Infow(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
 	} else {
-		log.internalLogger.Infof(template, args...)
+		log.internalLoggger.Infof(template, args...)
 	}
 }
 
 func (log Logger) Warn(ctx context.Context, template string, args ...interface{}) {
 	span, ok := tracer.SpanFromContext(ctx)
 	if ok {
-		log.internalLogger.Warnw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
+		log.internalLoggger.Warnw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
 	} else {
-		log.internalLogger.Warnf(template, args...)
+		log.internalLoggger.Warnf(template, args...)
 	}
 }
 
@@ -112,18 +119,18 @@ func (log Logger) Error(ctx context.Context, template string, args ...interface{
 	span, ok := tracer.SpanFromContext(ctx)
 	if ok {
 		span.SetTag("error", fmt.Errorf(template, args...))
-		log.internalLogger.Errorw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
+		log.internalLoggger.Errorw(fmt.Sprintf(template, args...), "dd.trace_id", span.Context().TraceID(), "dd.span_id", span.Context().SpanID())
 	} else {
-		log.internalLogger.Errorf(template, args...)
+		log.internalLoggger.Errorf(template, args...)
 	}
 }
 
 func (log Logger) Fatal(args ...interface{}) {
-	log.internalLogger.Fatal(args...)
+	log.internalLoggger.Fatal(args...)
 }
 
 func (log Logger) Sync() {
-	err := log.internalLogger.Sync()
+	err := log.internalLoggger.Sync()
 	if err != nil {
 		log.Fatal("unable to sync logs from buffer")
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -15,6 +15,10 @@ type Logger struct {
 	internalLoggger *zap.SugaredLogger
 }
 
+func (log *Logger) SetLogger(internalLogger *zap.SugaredLogger) {
+	log.internalLoggger = internalLogger
+}
+
 func NewLogger() Logger {
 	var logLevel zapcore.Level
 	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -77,14 +77,14 @@ func TestNewLogger(t *testing.T) {
 			logger := NewLogger(tt.option...)
 
 			// Test log level
-			if logger.internalLogger.Desugar().Core().Enabled(tt.expectedLevel) != true {
+			if logger.internalLoggger.Desugar().Core().Enabled(tt.expectedLevel) != true {
 				t.Errorf("Expected log level %v to be enabled", tt.expectedLevel)
 			}
 
 			// Test one level above should be disabled (except Fatal which is always highest)
 			if tt.expectedLevel != zapcore.FatalLevel {
 				nextLevel := tt.expectedLevel - 1
-				if logger.internalLogger.Desugar().Core().Enabled(nextLevel) != false {
+				if logger.internalLoggger.Desugar().Core().Enabled(nextLevel) != false {
 					t.Errorf("Expected log level %v to be disabled", nextLevel)
 				}
 			}
@@ -179,7 +179,7 @@ func TestLogFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			captureLog, logs := setupLogsCapture()
 			logger := Logger{
-				internalLogger: captureLog,
+				internalLoggger: captureLog,
 			}
 
 			switch tt.logLevel {
@@ -226,7 +226,7 @@ func TestLogFunctions(t *testing.T) {
 func TestFatalLogFunction(t *testing.T) {
 	captureLogger, logsCollector := setupLogsCapture()
 	logger := Logger{
-		internalLogger: captureLogger,
+		internalLoggger: captureLogger,
 	}
 
 	var panicked interface{}
@@ -267,7 +267,7 @@ func TestSync(t *testing.T) {
 	t.Run("successful sync", func(t *testing.T) {
 		captureLogger, _ := setupLogsCapture()
 		logger := Logger{
-			internalLogger: captureLogger,
+			internalLoggger: captureLogger,
 		}
 
 		// Should not panic
@@ -282,7 +282,7 @@ func TestSync(t *testing.T) {
 			zapcore.InfoLevel,
 		)
 		logger := Logger{
-			internalLogger: zap.New(core).Sugar().WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic)),
+			internalLoggger: zap.New(core).Sugar().WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic)),
 		}
 
 		var panicked interface{}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -24,6 +24,7 @@ func TestNewLogger(t *testing.T) {
 		name          string
 		logLevel      string
 		expectedLevel zapcore.Level
+		expectedName  string
 		option        []LoggerOption
 	}{
 		{
@@ -64,6 +65,12 @@ func TestNewLogger(t *testing.T) {
 				Encoding: "console",
 			})},
 		},
+		{
+			name:          "use option to provide logger name",
+			expectedLevel: zapcore.InfoLevel,
+			expectedName:  "my-logger",
+			option:        []LoggerOption{WithName("my-logger")},
+		},
 	}
 
 	for _, tt := range tests {
@@ -77,16 +84,20 @@ func TestNewLogger(t *testing.T) {
 			logger := NewLogger(tt.option...)
 
 			// Test log level
-			if logger.internalLoggger.Desugar().Core().Enabled(tt.expectedLevel) != true {
+			if logger.internalLogger.Desugar().Core().Enabled(tt.expectedLevel) != true {
 				t.Errorf("Expected log level %v to be enabled", tt.expectedLevel)
 			}
 
 			// Test one level above should be disabled (except Fatal which is always highest)
 			if tt.expectedLevel != zapcore.FatalLevel {
 				nextLevel := tt.expectedLevel - 1
-				if logger.internalLoggger.Desugar().Core().Enabled(nextLevel) != false {
+				if logger.internalLogger.Desugar().Core().Enabled(nextLevel) != false {
 					t.Errorf("Expected log level %v to be disabled", nextLevel)
 				}
+			}
+
+			if logger.Name() != tt.expectedName {
+				t.Errorf("Expected logger name to be '%s', got '%s'", tt.expectedName, logger.Name())
 			}
 		})
 	}
@@ -179,7 +190,7 @@ func TestLogFunctions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			captureLog, logs := setupLogsCapture()
 			logger := Logger{
-				internalLoggger: captureLog,
+				internalLogger: captureLog,
 			}
 
 			switch tt.logLevel {
@@ -226,7 +237,7 @@ func TestLogFunctions(t *testing.T) {
 func TestFatalLogFunction(t *testing.T) {
 	captureLogger, logsCollector := setupLogsCapture()
 	logger := Logger{
-		internalLoggger: captureLogger,
+		internalLogger: captureLogger,
 	}
 
 	var panicked interface{}
@@ -267,7 +278,7 @@ func TestSync(t *testing.T) {
 	t.Run("successful sync", func(t *testing.T) {
 		captureLogger, _ := setupLogsCapture()
 		logger := Logger{
-			internalLoggger: captureLogger,
+			internalLogger: captureLogger,
 		}
 
 		// Should not panic
@@ -282,7 +293,7 @@ func TestSync(t *testing.T) {
 			zapcore.InfoLevel,
 		)
 		logger := Logger{
-			internalLoggger: zap.New(core).Sugar().WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic)),
+			internalLogger: zap.New(core).Sugar().WithOptions(zap.WithFatalHook(zapcore.WriteThenPanic)),
 		}
 
 		var panicked interface{}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -83,6 +83,22 @@ func TestNewLogger(t *testing.T) {
 	}
 }
 
+func TestSetLogger(t *testing.T) {
+	captureLog, logs := setupLogsCapture()
+	logger := Logger{}
+	logger.SetLogger(captureLog)
+	logger.Info(context.Background(), "info text")
+	logger.Sync()
+
+	if len(logs.All()) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs.All()))
+	}
+	logEntry := logs.All()[0]
+	if logEntry.Message != "info text" {
+		t.Errorf("Message incorrect, expected '%s' got '%s'", "info text", logEntry.Message)
+	}
+}
+
 func TestLogFunctions(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()


### PR DESCRIPTION
Currently the logger shipped in the APM is hardcoded to ship data in JSON format, which makes a lot of sense when running in a live environment. When developing locally however, it is very inconvenient to work with logs in JSON format, as this make it more difficult to read the messages.

To make life easier using this package while developing locally a method is provided to pass options to both the apm and logger constructors, where through the latter custom Zap configuration can be passed.

```go
var myZapConfig *zap.Config
// Initialized elsewhere

func NewApm() apm.Apm {
  if os.getenv("LOGGING_ENV") == "local" {
    logger := logger.NewLogger(WithConfig(myZapConfig))
    return apm.NewApm(WithLogger(&logger)))
  }
  return apm.NewApm()
```