### PR TITLE
Changed level key to status and add error log level

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,6 +69,8 @@ func defaultLogger() *zap.SugaredLogger {
 		logLevel = zapcore.InfoLevel
 	case "warning":
 		logLevel = zapcore.WarnLevel
+	case "error":
+		logLevel = zapcore.ErrorLevel
 	case "fatal":
 		logLevel = zapcore.FatalLevel
 	default:
@@ -81,7 +83,7 @@ func defaultLogger() *zap.SugaredLogger {
 		Encoding:    "json",
 		EncoderConfig: zapcore.EncoderConfig{
 			TimeKey:        "time",
-			LevelKey:       "level",
+			LevelKey:       "status",
 			NameKey:        "logger",
 			CallerKey:      "caller",
 			MessageKey:     "msg",

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -239,6 +239,7 @@ func TestLogFunctions(t *testing.T) {
 }
 
 func TestFatalLogFunction(t *testing.T) {
+	//nolint:staticcheck // logsCollector is used but this is shadowed by the log.Fatal call
 	captureLogger, logsCollector := setupLogsCapture()
 	logger := Logger{
 		internalLogger: captureLogger,


### PR DESCRIPTION
This PR fixes two minor issues in the logger:
1. The log level `"error"` can now be selected as desired log level.
2. The level key is changed to `status` to be in line with Datadog's attribute names.