### PR TITLE
Update module url to use v2 suffix

### DIFF
--- a/apm/apm.go
+++ b/apm/apm.go
@@ -10,7 +10,7 @@ import (
 	chitrace "github.com/DataDog/dd-trace-go/contrib/go-chi/chi.v5/v2"
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	"github.com/YourSurpriseCom/go-datadog-apm/logger"
+	"github.com/YourSurpriseCom/go-datadog-apm/v2/logger"
 	"github.com/go-chi/chi/v5"
 )
 

--- a/apm/apm_test.go
+++ b/apm/apm_test.go
@@ -12,7 +12,7 @@ import (
 	chitrace "github.com/DataDog/dd-trace-go/contrib/go-chi/chi.v5/v2"
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
-	"github.com/YourSurpriseCom/go-datadog-apm/logger"
+	"github.com/YourSurpriseCom/go-datadog-apm/v2/logger"
 	"github.com/go-chi/chi/v5"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/YourSurpriseCom/go-datadog-apm
+module github.com/YourSurpriseCom/go-datadog-apm/v2
 
 go 1.24
 


### PR DESCRIPTION
Golang's non-v1 version apparently need to have the major version suffix in their module URL. This PR makes sure that our v2 actually works.